### PR TITLE
feat: Add dynamic header image to blog posts

### DIFF
--- a/cmd/web/create_edit_post_handlers.go
+++ b/cmd/web/create_edit_post_handlers.go
@@ -169,6 +169,7 @@ func (app *application) buildNewPost(form shared.BlogPostFormData, matter matter
 		Content:     content,
 		AuthorID:    userId,
 		Private:     matter.Private,
+		HeaderImage: matter.HeaderImage,
 	}
 }
 

--- a/ui/template/post_page.templ
+++ b/ui/template/post_page.templ
@@ -23,7 +23,7 @@ templ PostBase(title string, page templ.Component, data *shared.TemplateData) {
 				<meta property="og:description" content={ data.BlogPost.Description }/>
 			}
 			if data.BlogPost.HeaderImage != "" {
-				<meta property="og:image" content="/static/dist/img/icon_sm.png"/>
+				<meta property="og:image" content={ data.BlogPost.HeaderImage }/>
 			}
 			<meta name="theme-color" content="#a9a5bf"/>
 			<!-- Stylesheets -->


### PR DESCRIPTION
This commit introduces a change where the header image for blog posts is now dynamic. Previously, the header image was a static icon. Now, the header image is set based on the `HeaderImage` field of the blog post. This allows for more customization and better representation of the blog post content.